### PR TITLE
[NOREF/DO NOT MERGE] KenLM wheels (pt II)

### DIFF
--- a/build_manylinux1_wheels.sh
+++ b/build_manylinux1_wheels.sh
@@ -1,8 +1,33 @@
 #!/usr/bin/env bash
-set -ex
+set -eox
 
 # Install system packages required by libraries
-yum install -y libunistring-devel
+yum install -y libunistring-devel boost-devel wget xz-devel make gcc zlib-devel bzip2-devel cmake
+
+cd /
+
+# Install Eigen
+wget https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.zip
+unzip eigen-3.3.9.zip
+cd /eigen-3.3.9
+mkdir build
+cd build
+cmake ../ -DCMAKE_INSTALL_PREFIX=/installed/eigen3
+make install
+
+cd /io
+
+# re-create build dir
+rm -rf build && mkdir build
+
+# build binaries in build dir
+cd build
+cmake ../ -DEigen3_DIR=/installed/eigen3/share/eigen3  && make -j 8 && cd ..
+
+# copy binaries into kenlm_bin dir
+cp -r build/bin kenlm_bin/
+# remove previous wheels
+rm -rf wheels/tmp
 
 # Compile wheels
 for PYBIN in /opt/python/cp38-cp38/bin /opt/python/cp39-cp39/bin /opt/python/cp310-cp310/bin; do


### PR DESCRIPTION
Context [here](https://constructor.slack.com/archives/CT138D22C/p1674652428882089)

DO NOT MERGE ([reason](https://constructor.slack.com/archives/CT138D22C/p1674740306994309?thread_ts=1674652428.882089&cid=CT138D22C)):

>there’s another patch for the build script so that it builds and links the eigen3 correctly, but I’m having a bunch of Failed to validate index language_model at location /tmp/ac_files/ac_id_113018016_language_model.kenlm in the tests, which I can’t fix. Possibly my work can be used when you guys will update it to ARM anyway.
